### PR TITLE
Update archive_format.rs

### DIFF
--- a/runtime/src/snapshot_utils/archive_format.rs
+++ b/runtime/src/snapshot_utils/archive_format.rs
@@ -44,6 +44,7 @@ impl ArchiveFormat {
         match archive_format_str {
             "zstd" => Some(ArchiveFormat::TarZstd),
             "lz4" => Some(ArchiveFormat::TarLz4),
+            "tar" | "none" => Some(ArchiveFormat::Tar),
             _ => None,
         }
     }


### PR DESCRIPTION
#### Problem
Argument errors for solana-validator v1.17.0 & v1.17.1 specifying '--snapshot-archive-format <TYPE>'

Running v1.17.1 produces error for any mentioned archive format lz4 or zstd - ```error: 'none' isn't a valid value for '--snapshot-archive-format <ARCHIVE_TYPE>'
	[possible values: lz4, zstd]```

Running v1.17.0 gives ```error: The argument '--snapshot-archive-format <ARCHIVE_TYPE>' was provided more than once, but cannot be used multiple times```


#### Summary of Changes
return back line for ```"tar" | "none" => Some(ArchiveFormat::Tar),```


Fixes #
the command line argument for lz4/zstd needs to be accepted as well

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
